### PR TITLE
Add debug config for VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Jest Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--coverage", "false"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "name": "Current TS File",
+      "type": "node",
+      "request": "launch",
+      "args": ["${relativeFile}"],
+      "runtimeArgs": ["-r", "ts-node/register"],
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector",
+      "internalConsoleOptions": "openOnSessionStart"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "command": "npm",
+  "tasks": [
+    {
+      "label": "build",
+      "type": "shell",
+      "args": ["run", "build"],
+      "problemMatcher": [],
+      "group": {
+        "_id": "build",
+        "isDefault": false
+      }
+    },
+    {
+      "label": "test",
+      "type": "shell",
+      "args": ["run", "jest", "${relativeFile}"],
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
**Configuration files for debugging in VS code including debugging tests (using Jest framework).** 

**To debug:**
1. From VS Code, select the `index.ts` file
2. Click Run and Debug on the left
3. Click the Play icon up top > Current TS File

**References:**
Blog post on debugging TS without compiling:
https://medium.com/@dupski/debug-typescript-in-vs-code-without-compiling-using-ts-node-9d1f4f9a94a

Repo: 
https://github.com/Enterprise-JS/vscode-ts-node-debugging

Jest configuration:
https://medium.com/@mtiller/debugging-with-typescript-jest-ts-jest-and-visual-studio-code-ef9ca8644132